### PR TITLE
make: fix dependency problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ $(LIBANYIO) : $(objects)
 mesaflash.o : mesaflash.c $(headers)
 	$(CC) $(CFLAGS) -c mesaflash.c
 
-$(BIN): mesaflash.o anyio.h
+$(BIN): mesaflash.o anyio.h $(LIBANYIO)
 	$(CC) -o $(BIN) mesaflash.o $(LIBANYIO) $(LIBS)
 
 anyio.o : anyio.c $(headers)


### PR DESCRIPTION
When building with a large "-j" value, the build could fail with a message like
    gcc -o mesaflash mesaflash.o libanyio.a -lpci -lm
    gcc: error: libanyio.a: No such file or directory
    Makefile:70: recipe for target 'mesaflash' failed
    make: *** [mesaflash] Error 1
make mesaflash explicitly depend on libanyio.a to avoid this.

Signed-off-by: Jeff Epler <jepler@unpythonic.net>