### PR TITLE
debian: Add rules to create a +dfsg tarball

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,3 +5,33 @@
 
 override_dh_auto_install:
 	$(MAKE) DESTDIR=$$(pwd)/debian/mesaflash/usr install
+
+PKD   = $(abspath $(dir $(MAKEFILE_LIST)))
+PKG   = $(word 2,$(shell dpkg-parsechangelog -l$(PKD)/changelog | grep ^Source))
+UVER  = $(shell dpkg-parsechangelog -l$(PKD)/changelog | perl -ne 'print $$1 if m{^Version:\s+(?:\d+:)?(\d.*)(?:\-\d+.*)};')
+DTYPE = +dfsg
+VER  ?= $(subst $(DTYPE),,$(UVER))
+
+.PHONY: get-orig-source
+get-orig-source: $(PKG)_$(VER)$(DTYPE).orig.tar.xz $(info I: $(PKG)_$(VER)$(DTYPE))
+
+
+$(PKG)_$(VER)$(DTYPE).orig.tar.xz:
+	@echo "# Downloading..."
+	uscan --noconf --verbose --rename --destdir=$(CURDIR) --check-dirname-level=0 --force-download --download-version $(VER) $(PKD)
+	$(if $(wildcard $(PKG)-$(VER)),$(error $(PKG)-$(VER) exist, aborting..))
+	@echo "# Extracting..."
+	mkdir $(PKG)-$(VER) \
+	&& tar -xf $(PKG)_$(VER).orig.tar.* --directory $(PKG)-$(VER) --strip-components 1 \
+	|| $(RM) -r $(PKG)-$(VER)
+	@echo "# Cleaning-up..."
+	cd $(PKG)-$(VER) \
+	&& $(RM) -r -v \
+	    debian \
+	    winio32 \
+	    WinIo32.*
+	#$(RM) -v $(PKG)_$(VER).orig.tar.*
+	@echo "# Packing..."
+	find -L "$(PKG)-$(VER)" -xdev -type f -print | LC_ALL=C sort \
+	| XZ_OPT="-6v" tar -caf "$(PKG)_$(VER)$(DTYPE).orig.tar.xz" -T- --owner=root --group=root --mode=a+rX \
+	&& $(RM) -r "$(PKG)-$(VER)"

--- a/debian/rules
+++ b/debian/rules
@@ -29,7 +29,9 @@ $(PKG)_$(VER)$(DTYPE).orig.tar.xz:
 	&& $(RM) -r -v \
 	    debian \
 	    winio32 \
-	    WinIo32.*
+	    WinIo32.* \
+	    libpci.dll \
+	    libpci
 	#$(RM) -v $(PKG)_$(VER).orig.tar.*
 	@echo "# Packing..."
 	find -L "$(PKG)-$(VER)" -xdev -type f -print | LC_ALL=C sort \

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)

--- a/debian/watch
+++ b/debian/watch
@@ -1,0 +1,3 @@
+version=3
+opts=filenamemangle=s/.+\/v?(\d\S*)\.tar\.gz/mesaflash-$1\.tar\.gz/ \
+  https://github.com/micges/mesaflash/tags .*/v?(\d\S*)\.tar\.gz


### PR DESCRIPTION
At the next release, this will require
 * Creating a tag on github like "v3.2.0"
 * Using a Debian version number like "3.2.0+dsfg-1"
but it will get us what we want for a Debian package (a source tarball
that excludes the non-DFSG-free 'winio' packages) without breaking the
mesaflash git repository's ability to build for/on Windows.

Since there are no tags at the moment, I tested this by temporarily
naming jepler/mesaflash in debian/watch, and creating a tag there.
It seems to work.

Signed-off-by: Jeff Epler <jepler@unpythonic.net>