### PR TITLE
New ethernet boards

### DIFF
--- a/anyio.c
+++ b/anyio.c
@@ -33,6 +33,7 @@ supported_board_entry_t supported_boards[] = {
     {"ETHER", BOARD_ETH | BOARD_WILDCARD},
     {"7I92", BOARD_ETH},
     {"7I93", BOARD_ETH},
+    {"7I96", BOARD_ETH},
     {"7I80", BOARD_ETH},
     {"7I76E", BOARD_ETH},
 

--- a/anyio.c
+++ b/anyio.c
@@ -188,16 +188,16 @@ int anyio_find_dev(board_access_t *access) {
 
 board_t *anyio_get_dev(board_access_t *access, int board_number) {
     int i, j;
-    board_t *board = NULL;
 
     if (access == NULL) {
         return NULL;
     }
     for (i = 0, j = 0; i < boards_count; i++) {
-        if (strncmp(access->device_name, boards[i].llio.board_name, strlen(access->device_name)) == 0) {
+        board_t *board = NULL;
+        board = &boards[i];
+        if (strncmp(access->device_name, board->llio.board_name, strlen(access->device_name)) == 0) {
             j++;
             if (j == board_number) {
-                board = &boards[i];
                 return board;
             }
         }

--- a/anyio.c
+++ b/anyio.c
@@ -30,6 +30,7 @@
 #include "serial_boards.h"
 
 supported_board_entry_t supported_boards[] = {
+    {"ETHER", BOARD_ETH | BOARD_WILDCARD},
     {"7I92", BOARD_ETH},
     {"7I80", BOARD_ETH},
     {"7I76E", BOARD_ETH},
@@ -105,6 +106,8 @@ int anyio_find_dev(board_access_t *access) {
     }
 
     access->open_iface = 0;
+    if (supported_board->type & BOARD_WILDCARD)
+        access->open_iface = BOARD_WILDCARD;
     if (access->type == BOARD_ANY) {
         if (supported_board->type & BOARD_MULTI_INTERFACE) {
             printf("ERROR: you must select transport layer for board\n");
@@ -195,7 +198,7 @@ board_t *anyio_get_dev(board_access_t *access, int board_number) {
     for (i = 0, j = 0; i < boards_count; i++) {
         board_t *board = NULL;
         board = &boards[i];
-        if (strncmp(access->device_name, board->llio.board_name, strlen(access->device_name)) == 0) {
+        if (strncmp(access->device_name, board->llio.board_name, strlen(access->device_name)) == 0 || access->open_iface & BOARD_WILDCARD) {
             j++;
             if (j == board_number) {
                 return board;

--- a/anyio.c
+++ b/anyio.c
@@ -32,6 +32,7 @@
 supported_board_entry_t supported_boards[] = {
     {"ETHER", BOARD_ETH | BOARD_WILDCARD},
     {"7I92", BOARD_ETH},
+    {"7I93", BOARD_ETH},
     {"7I80", BOARD_ETH},
     {"7I76E", BOARD_ETH},
 

--- a/boards.h
+++ b/boards.h
@@ -36,6 +36,7 @@
 #define BOARD_USB             (1<<4)
 #define BOARD_SPI             (1<<5)
 #define BOARD_SER             (1<<6)
+#define BOARD_WILDCARD        (1<<30)
 typedef enum {BOARD_MODE_CPLD, BOARD_MODE_FPGA} board_mode;
 typedef enum {BOARD_FLASH_NONE = 0, BOARD_FLASH_HM2, BOARD_FLASH_IO, BOARD_FLASH_GPIO, BOARD_FLASH_REMOTE, BOARD_FLASH_EPP} board_flash;
 

--- a/eth_boards.c
+++ b/eth_boards.c
@@ -300,6 +300,29 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->flash = BOARD_FLASH_REMOTE;
             board->fallback_support = 1;
             board->llio.verbose = access->verbose;
+        } else if (strncmp(buff, "7I93", 4) == 0) {
+            board->type = BOARD_ETH;
+            strncpy(board->dev_addr, eth_socket_get_src_ip(), 16);
+            strncpy(board->llio.board_name, buff, 16);
+            board->llio.num_ioport_connectors = 2;
+            board->llio.pins_per_connector = 24;
+            board->llio.ioport_connector_name[0] = "P2";
+            board->llio.ioport_connector_name[1] = "P1";
+            board->llio.fpga_part_number = "6slx9tqg144";
+            board->llio.num_leds = 4;
+            board->llio.read = &eth_read;
+            board->llio.write = &eth_write;
+            board->llio.write_flash = &remote_write_flash;
+            board->llio.verify_flash = &remote_verify_flash;
+            board->llio.reset = &lbp16_board_reset;
+            board->llio.reload = &lbp16_board_reload;
+
+            board->open = &eth_board_open;
+            board->close = &eth_board_close;
+            board->print_info = &eth_print_info;
+            board->flash = BOARD_FLASH_REMOTE;
+            board->fallback_support = 1;
+            board->llio.verbose = access->verbose;
         } else {
             printf("Unsupported ethernet device %s at %s\n", buff, eth_socket_get_src_ip());
             ret = -1;

--- a/eth_boards.c
+++ b/eth_boards.c
@@ -323,6 +323,31 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->flash = BOARD_FLASH_REMOTE;
             board->fallback_support = 1;
             board->llio.verbose = access->verbose;
+        } else if (strncmp(buff, "7I96", 4) == 0) {
+            board->type = BOARD_ETH;
+            strncpy(board->dev_addr, eth_socket_get_src_ip(), 16);
+            strncpy(board->llio.board_name, buff, 16);
+            board->llio.num_ioport_connectors = 3;
+            board->llio.pins_per_connector = 13;
+            board->llio.ioport_connector_name[0] = "P1";
+            board->llio.ioport_connector_name[1] = "TB1";
+            board->llio.ioport_connector_name[2] = "TB2";
+            board->llio.ioport_connector_name[3] = "TB3";
+            board->llio.fpga_part_number = "6slx9tqg144";
+            board->llio.num_leds = 4;
+            board->llio.read = &eth_read;
+            board->llio.write = &eth_write;
+            board->llio.write_flash = &remote_write_flash;
+            board->llio.verify_flash = &remote_verify_flash;
+            board->llio.reset = &lbp16_board_reset;
+            board->llio.reload = &lbp16_board_reload;
+
+            board->open = &eth_board_open;
+            board->close = &eth_board_close;
+            board->print_info = &eth_print_info;
+            board->flash = BOARD_FLASH_REMOTE;
+            board->fallback_support = 1;
+            board->llio.verbose = access->verbose;
         } else {
             printf("Unsupported ethernet device %s at %s\n", buff, eth_socket_get_src_ip());
             ret = -1;

--- a/hostmot2.c
+++ b/hostmot2.c
@@ -95,6 +95,7 @@ const char *hm2_get_general_function_name(int gtag) {
         case HM2_GTAG_RESOLVER:          return "Resolver";
         case HM2_GTAG_SSERIAL:           return "Smart Serial Interface";
         case HM2_GTAG_TWIDDLER:          return "TWIDDLER";
+        case HM2_GTAG_XFORMER:           return "Transformer";
         default: {
             static char unknown[100];
             snprintf(unknown, 100, "(unknown-gtag-%d)", gtag);
@@ -419,6 +420,7 @@ static pin_name_t pin_names[HM2_MAX_TAGS] = {
   {HM2_GTAG_RESOLVER,  {"PwrEn", "PDMP", "PDMM", "ADChan0", "ADChan1", "ADChan2", "SPICS", "SPIClk", "SPIDI0", "SPIDI1"}},
   {HM2_GTAG_SSERIAL,  {"RXData", "TXData", "TXEn", "TestPin", "Null5", "Null6", "Null7", "Null8", "Null9", "Null10"}},
   {HM2_GTAG_TWIDDLER,  {"InBit", "IOBit", "OutBit", "Null4", "Null5", "Null6", "Null7", "Null8", "Null9", "Null10"}},
+  {HM2_GTAG_XFORMER,  {"Drive", "Ref", "Null3", "Null4", "Null5", "Null6", "Null7", "Null8", "Null9", "Null10"}},
   {HM2_GTAG_SPI,      {"/Frame", "DOut", "SClk", "DIn", "Null5", "Null6", "Null7", "Null8", "Null9", "Null10"}},
   {HM2_GTAG_BSPI,     {"/Frame", "DOut", "SClk", "DIn", "CS0", "CS1", "CS2", "CS3", "Null9", "Null10"}},
   {HM2_GTAG_DBSPI,    {"Null1", "DOut", "SClk", "DIn", "/CS-FRM0", "/CS-FRM1", "/CS-FRM2", "/CS-FRM3", "Null9", "Null10"}},
@@ -450,6 +452,7 @@ static pin_name_t pin_names_xml[HM2_MAX_TAGS] = {
   {HM2_GTAG_RESOLVER,  {"PwrEn", "PDMP", "PDMM", "ADChan0", "ADChan1", "ADChan2", "SPICS", "SPIClk", "SPIDI0", "SPIDI1"}},
   {HM2_GTAG_SSERIAL,  {"RXData", "TXData", "TXEn", "TestPin", "Null5", "Null6", "Null7", "Null8", "Null9", "Null10"}},
   {HM2_GTAG_TWIDDLER,  {"InBit", "IOBit", "OutBit", "Null4", "Null5", "Null6", "Null7", "Null8", "Null9", "Null10"}},
+  {HM2_GTAG_XFORMER,  {"Drive", "Ref", "Null3", "Null4", "Null5", "Null6", "Null7", "Null8", "Null9", "Null10"}},
   {HM2_GTAG_SPI,      {"/Frame", "DOut", "SClk", "DIn", "Null5", "Null6", "Null7", "Null8", "Null9", "Null10"}},
   {HM2_GTAG_BSPI,     {"/Frame", "DOut", "SClk", "DIn", "CS0", "CS1", "CS2", "CS3", "Null9", "Null10"}},
   {HM2_GTAG_DBSPI,    {"Null1", "DOut", "SClk", "DIn", "/CS-FRM0", "/CS-FRM1", "/CS-FRM2", "/CS-FRM3", "Null9", "Null10"}},
@@ -491,6 +494,7 @@ static mod_name_t mod_names[HM2_MAX_TAGS] = {
     {"ResolverMod", HM2_GTAG_RESOLVER},
     {"SSerial",     HM2_GTAG_SSERIAL},
     {"Twiddler",    HM2_GTAG_TWIDDLER},
+    {"Transformer", HM2_GTAG_XFORMER},
 };
 
 static mod_name_t mod_names_xml[HM2_MAX_TAGS] = {
@@ -523,6 +527,7 @@ static mod_name_t mod_names_xml[HM2_MAX_TAGS] = {
     {"ResolverMod", HM2_GTAG_RESOLVER},
     {"SSerial",     HM2_GTAG_SSERIAL},
     {"Twiddler",    HM2_GTAG_TWIDDLER},
+    {"Transformer", HM2_GTAG_XFORMER},
 };
 
 static char *pin_find_module_name(int gtag, int xml_flag) {

--- a/hostmot2.h
+++ b/hostmot2.h
@@ -36,7 +36,7 @@ typedef struct {
     int sw_modes_cnt;
 } sserial_device_t;
 
-#define HM2_MAX_TAGS     29
+#define HM2_MAX_TAGS     30
 #define ANYIO_MAX_IOPORT_CONNECTORS 8
 
 typedef struct llio_struct llio_t;

--- a/hostmot2_def.h
+++ b/hostmot2_def.h
@@ -64,6 +64,7 @@
 #define HM2_GTAG_RESOLVER          0xC0
 #define HM2_GTAG_SSERIAL           0xC1
 #define HM2_GTAG_TWIDDLER          0xC2
+#define HM2_GTAG_XFORMER           0xC3
 
 // HM2 EEPROM SPI INTERFACE
 


### PR DESCRIPTION
This adds support for the 7i96 and 7i93, as well as a board name "ETHER" which accepts any kind of ethernet board (including unknown ones)